### PR TITLE
correct button close and responsive

### DIFF
--- a/src/components/Hero.jsx
+++ b/src/components/Hero.jsx
@@ -12,7 +12,7 @@ function Hero() {
   return (
     <section className="relative text-white">
       <div
-        className="h-[400px] md:h-[600px] w-full bg-cover bg-center"
+        className="h-[600px] md:h-[600px] w-full bg-cover bg-center"
         style={{
           backgroundImage: `url(${bck})`,
         }}
@@ -45,7 +45,7 @@ function Hero() {
 
       <div className="absolute bottom-8 right-8 ">
         <div
-          className={`bg-cyan-600 hover:bg-cyan-700 transition-all duration-300 rounded-full p-3 cursor-pointer ${click ? 'w-auto' : 'w-16 h-16 flex items-center justify-center'}`}
+          className={`bg-cyan-600 hover:bg-cyan-700 transition-all duration-300 rounded-lg p-3 cursor-pointer ${click ? 'w-auto' : 'w-16 h-16 flex items-center justify-center'}`}
           onClick={() => setClick(!click)}
         >
           {click ? (

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -31,7 +31,7 @@ function Nav() {
 
   return (
     <header
-      className={`sticky top-0 z-50 transition-all duration-300 ${isScrolled ? "bg-gray-900/80 backdrop-blur-lg shadow-lg" : "bg-transparent"
+      className={`sticky top-0 z-50 transition-all duration-300 ${isScrolled ? "bg-gray-900/80 backdrop-blur-lg shadow-lg" : "bg-cyan-600/80"
         }`}
     >
       <nav className="container mx-auto flex items-center justify-between p-4 text-white">
@@ -59,7 +59,8 @@ function Nav() {
         <div className="md:hidden">
           <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="z-50">
             {isMenuOpen ? (
-              <IoIosCloseCircleOutline className="h-8 w-8 text-cyan-400" />
+              // <IoIosCloseCircleOutline className="h-8 w-8 text-cyan-400" />
+              ""
             ) : (
               <RiMenu4Line className="h-8 w-8 text-white" />
             )}
@@ -71,6 +72,10 @@ function Nav() {
           className={`absolute top-0 left-0 w-full h-screen bg-gray-900/95 md:hidden flex flex-col items-center justify-center transition-transform duration-300 ease-in-out ${isMenuOpen ? "translate-x-0" : "-translate-x-full"
             }`}
         >
+
+          <button onClick={() => setIsMenuOpen(!isMenuOpen)} className="absolute top-4 right-4">
+            <IoIosCloseCircleOutline className="h-8 w-8 text-cyan-400" />
+          </button>
           {navLinks.map((link) => (
             <a
               key={link.title}


### PR DESCRIPTION
## Summary by Sourcery

Adjust navigation bar background behavior, relocate the mobile menu close button, and standardize hero section styling for improved responsiveness

Enhancements:
- Set the navbar to use a semi-transparent cyan background when not scrolled
- Move the mobile menu’s close button into the off-canvas panel and remove it from the header toggle
- Standardize the hero background height to 600px on all screen sizes
- Change the hero action button from a circular to a rounded-rectangle style