### PR TITLE
Update CV link

### DIFF
--- a/src/components/Portfolio.jsx
+++ b/src/components/Portfolio.jsx
@@ -2,7 +2,6 @@ import React from 'react';
 import certImg from '../assets/cert.png';
 import cvImg from '../assets/cv.png';
 import certificatPDF from '../assets/path/to/certificat.pdf';
-import cvPDF from '../assets/path/to/cv.pdf';
 
 const portfolioItems = [
   {
@@ -13,7 +12,7 @@ const portfolioItems = [
   {
     title: 'CV',
     image: cvImg,
-    link: cvPDF,
+    link: "https://mon-cv-one-phi.vercel.app",
   },
 ];
 


### PR DESCRIPTION
## Summary by Sourcery

Update the CV portfolio item to link to an external URL instead of the local PDF

Enhancements:
- Replace the CV link value with a hosted URL
- Remove the unused import of the local CV PDF file