### PR TITLE
Init Convex client in browser at runtime with loading state

### DIFF
--- a/src/context/ConvexClientProvider.tsx
+++ b/src/context/ConvexClientProvider.tsx
@@ -1,15 +1,31 @@
 "use client"
 
 import { ConvexReactClient } from "convex/react"
-import { ReactNode } from "react"
+import { ReactNode, useEffect, useState } from "react"
 import { ConvexProvider } from "convex/react"
 
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!)
-
 export const ConvexClientProvider = ({ children }: { children: ReactNode }) => {
+    const [convex, setConvex] = useState<ConvexReactClient | null>(null);
+
+    useEffect(() => {
+        // This ensures we're in the browser before initializing Convex
+        if (typeof window !== 'undefined') {
+            const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+            if (!convexUrl) {
+                console.error("NEXT_PUBLIC_CONVEX_URL is not set. Make sure to add it to your .env file.");
+                return;
+            }
+            setConvex(new ConvexReactClient(convexUrl));
+        }
+    }, []);
+
+    if (!convex) {
+        return <div>Loading...</div>;
+    }
+
     return (
         <ConvexProvider client={convex}>
             {children}
         </ConvexProvider>
-    )
-}
+    );
+};


### PR DESCRIPTION
## Summary
Initialize the Convex client on the client side at runtime instead of at module load time to ensure proper browser-only configuration handling.

Enhancements:
- Guard Convex client initialization behind a browser check and runtime-loaded environment variable.
- Add a loading state while the Convex client is being initialized to avoid rendering children without a configured client.